### PR TITLE
[CU-2tz8cah] 債務/債務者API呼び出し時にOptionの項目がNoneの場合はリクエストパラメータに含めないようにした。

### DIFF
--- a/src/debt.rs
+++ b/src/debt.rs
@@ -35,12 +35,17 @@ pub struct DebtRequest {
     pub debtor_id: String,
     pub dealt_at: DateTime<Local>,
     pub debt_amount: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub debt_fee: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub debt_delinquency_charge: Option<i64>,
     pub repayment_due_at: DateTime<Local>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub appendix: Option<String>,
     pub remind_segments: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub partner: Option<Partner>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub debt_status: Option<DebtStatusRequest>,
 }
 

--- a/src/debtor.rs
+++ b/src/debtor.rs
@@ -42,6 +42,7 @@ pub struct DebtorRequest {
     pub debtor_id: String,
     pub name: String,
     pub name_kana: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub birth_date: Option<NaiveDate>,
     pub gender: Gender,
     pub email: String,


### PR DESCRIPTION
Noneだと`null`という文字列が入ってしまうのでNoneの場合はkeyも指定無しにした。