### PR TITLE
[CU-2y8jtgr] requestをdisplayに出してしまうとログ出力する時などに個人情報が漏れてしまうので、構造体の中には残すが文字列にする時には出力しないようにした

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -13,19 +13,19 @@ use super::remind_group::remind::Remind;
 /// TODO: debtorでもdebtsでも使えるようにrequest,responseをStringにしているがDebtor以外の型ができたタイミングでGenericsにしたほうがいい気がする
 #[derive(thiserror::Error, Debug)]
 pub enum LectoError {
-    #[error("Status: {status} Req: {request:#?} Res: {response:#?}")]
+    #[error("Status: {status} Res: {response:#?}")]
     UnprocessableEntity {
         status: StatusCode,
         request: String,
         response: String,
     },
-    #[error("Status: {status} Req: {request:#?} Res: {response:#?}")]
+    #[error("Status: {status} Res: {response:#?}")]
     BadRequest {
         status: StatusCode,
         request: String,
         response: String,
     },
-    #[error("Status: {status} Req: {request:#?} Res: {response:#?}")]
+    #[error("Status: {status} Res: {response:#?}")]
     InternalServerError {
         status: StatusCode,
         request: String,


### PR DESCRIPTION
表題の通りです！
