### PR TITLE
[CU-376ku9b] 債務更新APIがセグメントにNullを指定すると上書きはしない仕様となったのでPostの時に使用する構造体のセグメントをOptionにしてNull指定ができるようにした

### DIFF
--- a/src/debt.rs
+++ b/src/debt.rs
@@ -42,6 +42,7 @@ pub struct DebtRequest {
     pub repayment_due_at: DateTime<Local>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub appendix: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub remind_segments: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub partner: Option<Partner>,

--- a/src/debt.rs
+++ b/src/debt.rs
@@ -42,7 +42,7 @@ pub struct DebtRequest {
     pub repayment_due_at: DateTime<Local>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub appendix: Option<String>,
-    pub remind_segments: Vec<String>,
+    pub remind_segments: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub partner: Option<Partner>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -76,7 +76,7 @@ mod tests {
             appendix: Some(
                 r#"lease_id:xxxx lease_contract_id:xxxxx item_name:Windowsノートパソコン transaction_id:HGBVPKRN_1LCBU8F requester_name:ヤギ ナツキ total_amount:15240 elapsed_month:-2"#.into(),
             ),
-            remind_segments: vec!["y2021".into()],
+            remind_segments: Some(vec!["y2021".into()]),
             partner: Some(Partner {
                 id: "1234-5678".into(),
                 name: "加盟店アメリケン".into(),

--- a/src/fixture.rs
+++ b/src/fixture.rs
@@ -33,7 +33,7 @@ pub fn debt_request_sample_data() -> DebtRequest {
         appendix: Some(
             r#"lease_id:xxxx lease_contract_id:xxxxx item_name:Windowsノートパソコン transaction_id:HGBVPKRN_1LCBU8F requester_name:ヤギ ナツキ total_amount:15240 elapsed_month:-2"#.into(),
         ),
-        remind_segments: vec!["y2021".into()],
+        remind_segments: Some(vec!["y2021".into()]),
         partner: Some(Partner {
             id: "1234-5678".into(),
             name: "加盟店アメリケン".into(),


### PR DESCRIPTION
#なにこれ

こちらの仕様変更に対応するための修正です。
https://app.clickup.com/t/35yn19w

