### PR TITLE
spark/bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lecto_client"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lecto_client"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 publish = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lecto_client"
-version = "0.11.0"
+version = "0.10.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
- **revert version**
- **chore: Release lecto_client version 0.11.0**
